### PR TITLE
Speed up multi-file source construction and reduce jobconf bloat

### DIFF
--- a/crunch-core/src/main/java/org/apache/crunch/io/impl/FileSourceImpl.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/impl/FileSourceImpl.java
@@ -100,9 +100,7 @@ public class FileSourceImpl<T> implements Source<T> {
   public void configureSource(Job job, int inputId) throws IOException {
     // Use Crunch to handle the combined input splits
     job.setInputFormatClass(CrunchInputFormat.class);
-    for (Path path : paths) {
-      CrunchInputs.addInputPath(job, path, inputBundle, inputId);
-    }
+    CrunchInputs.addInputPaths(job, paths, inputBundle, inputId);
   }
 
   public FormatBundle<? extends InputFormat> getBundle() {


### PR DESCRIPTION
Currently every individual file is appended to jobconf individually with serialized schema, i.e., duplicating the schema for every file. For a couple of thousands of files this takes several minutes and bloats the jobconf triggering "Exceeded max jobconf size" exception.
