### PR TITLE
CRUNCH-660, CRUNCH-675: Use DistCp instead of FileUtils.copy when sou…

### DIFF
--- a/crunch-core/pom.xml
+++ b/crunch-core/pom.xml
@@ -67,6 +67,12 @@ under the License.
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-distcp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Override the slf4j dependency from Avro, which is incompatible with
          Hadoop's. -->
     <dependency>

--- a/crunch-core/src/main/java/org/apache/crunch/impl/mr/run/RuntimeParameters.java
+++ b/crunch-core/src/main/java/org/apache/crunch/impl/mr/run/RuntimeParameters.java
@@ -47,6 +47,10 @@ public final class RuntimeParameters {
 
   public static final String MAX_POLL_INTERVAL = "crunch.max.poll.interval";
 
+  public static final String FILE_TARGET_USE_DISTCP = "crunch.file.target.use.distcp";
+
+  public static final String FILE_TARGET_MAX_DISTCP_TASKS = "crunch.file.target.max.distcp.tasks";
+
   // Not instantiated
   private RuntimeParameters() {
   }

--- a/crunch-hbase/pom.xml
+++ b/crunch-hbase/pom.xml
@@ -56,6 +56,12 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-distcp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>
       <type>jar</type>

--- a/crunch-hbase/src/main/java/org/apache/crunch/io/hbase/HFileTarget.java
+++ b/crunch-hbase/src/main/java/org/apache/crunch/io/hbase/HFileTarget.java
@@ -17,12 +17,16 @@
  */
 package org.apache.crunch.io.hbase;
 
+import org.apache.crunch.CrunchRuntimeException;
+import org.apache.crunch.impl.mr.run.RuntimeParameters;
 import org.apache.crunch.io.SequentialFileNamingScheme;
 import org.apache.crunch.io.impl.FileTargetImpl;
 import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PTableType;
 import org.apache.crunch.types.PType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -30,8 +34,17 @@ import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.mapreduce.KeyValueSerialization;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.tools.DistCp;
+import org.apache.hadoop.tools.DistCpOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 public class HFileTarget extends FileTargetImpl {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HFileTarget.class);
 
   public HFileTarget(String path) {
     this(new Path(path));
@@ -75,6 +88,64 @@ public class HFileTarget extends FileTargetImpl {
       return new HBasePairConverter<ImmutableBytesWritable, Cell>(ImmutableBytesWritable.class, Cell.class);
     }
     return new HBaseValueConverter<Cell>(Cell.class);
+  }
+
+  @Override
+  public void handleOutputs(Configuration conf, Path workingPath, int index) throws IOException {
+    FileSystem srcFs = workingPath.getFileSystem(conf);
+    Path src = getSourcePattern(workingPath, index);
+    Path[] srcs = FileUtil.stat2Paths(srcFs.globStatus(src), src);
+    FileSystem dstFs = path.getFileSystem(conf);
+    if (!dstFs.exists(path)) {
+      dstFs.mkdirs(path);
+    }
+    boolean sameFs = isCompatible(srcFs, path);
+
+    if (!sameFs) {
+      if (srcs.length > 0) {
+        int maxDistributedCopyTasks = conf.getInt(RuntimeParameters.FILE_TARGET_MAX_DISTCP_TASKS, 1000);
+        LOG.info(
+                "Source and destination are in different file systems, performing distcp of {} files from [{}] to [{}] "
+                        + "using at most {} tasks",
+                new Object[] { srcs.length, src, path, maxDistributedCopyTasks });
+        // Once https://issues.apache.org/jira/browse/HADOOP-15281 is available, we can use the direct write
+        // distcp optimization if the target path is in S3
+        DistCpOptions options = new DistCpOptions(Arrays.asList(srcs), path);
+        options.setMaxMaps(maxDistributedCopyTasks);
+        options.setOverwrite(true);
+        options.setBlocking(true);
+
+        Configuration distCpConf = new Configuration(conf);
+        // Remove unnecessary and problematic properties from the DistCp configuration. This is necessary since
+        // files referenced by these properties may have already been deleted when the DistCp is being started.
+        distCpConf.unset("mapreduce.job.cache.files");
+        distCpConf.unset("mapreduce.job.classpath.files");
+        distCpConf.unset("tmpjars");
+
+        try {
+          DistCp distCp = new DistCp(distCpConf, options);
+          if (!distCp.execute().isSuccessful()) {
+            throw new CrunchRuntimeException("Unable to move files through distcp from " + src + " to " + path);
+          }
+          LOG.info("Distributed copy completed for {} files", srcs.length);
+        } catch (Exception e) {
+          throw new CrunchRuntimeException("Unable to move files through distcp from " + src + " to " + path, e);
+        }
+      } else {
+        LOG.info("No files found at [{}], not attempting to copy HFiles", src);
+      }
+    } else {
+      LOG.info(
+              "Source and destination are in the same file system, performing rename of {} files from [{}] to [{}]",
+              new Object[] { srcs.length, src, path });
+
+      for (Path s : srcs) {
+        Path d = getDestFile(conf, s, path, s.getName().contains("-m-"));
+        srcFs.rename(s, d);
+      }
+    }
+    dstFs.create(getSuccessIndicator(), true).close();
+    LOG.info("Created success indicator file");
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@ under the License.
       </dependency>
 
       <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-distcp</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.hive.hcatalog</groupId>
         <artifactId>hive-hcatalog-core</artifactId>
         <version>${hive.version}</version>


### PR DESCRIPTION
…rce and destination paths are in different filesystems