### PR TITLE
CRUNCH-677 Source and Target accept FileSystem

### DIFF
--- a/crunch-core/pom.xml
+++ b/crunch-core/pom.xml
@@ -129,6 +129,12 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/crunch-core/src/it/java/org/apache/crunch/ExternalFilesystemIT.java
+++ b/crunch-core/src/it/java/org/apache/crunch/ExternalFilesystemIT.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.crunch;
+
+import static org.apache.hadoop.hdfs.MiniDFSCluster.HDFS_MINIDFS_BASEDIR;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.apache.commons.io.IOUtils;
+import org.apache.crunch.impl.mr.MRPipeline;
+import org.apache.crunch.io.From;
+import org.apache.crunch.io.To;
+import org.apache.crunch.test.TemporaryPath;
+import org.apache.crunch.test.TemporaryPaths;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.MiniDFSCluster.Builder;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Tests reading and writing from a FileSystem for which the Configuration is separate from the Pipeline's
+ * Configuration.
+ */
+public class ExternalFilesystemIT {
+
+    @ClassRule
+    public static TemporaryPath tmpDir1 = TemporaryPaths.create();
+
+    @ClassRule
+    public static TemporaryPath tmpDir2 = TemporaryPaths.create();
+
+    @ClassRule
+    public static TemporaryPath tmpDir3 = TemporaryPaths.create();
+
+    private static FileSystem dfsCluster1;
+    private static FileSystem dfsCluster2;
+    private static FileSystem defaultFs;
+
+    private static Collection<MiniDFSCluster> miniDFSClusters = new ArrayList<>();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        dfsCluster1 = createHaMiniClusterFs("cluster1", tmpDir1);
+        dfsCluster2 = createHaMiniClusterFs("cluster2", tmpDir2);
+        defaultFs = createHaMiniClusterFs("default", tmpDir3);
+    }
+
+    @AfterClass
+    public static void teardown() throws IOException {
+        dfsCluster1.close();
+        dfsCluster2.close();
+        defaultFs.close();
+        for (MiniDFSCluster miniDFSCluster : miniDFSClusters) {
+            miniDFSCluster.shutdown();
+        }
+    }
+
+    @Test
+    public void testReadWrite() throws Exception {
+        // write a test file outside crunch
+        Path path = new Path("hdfs://cluster1/input.txt");
+        String testString = "Hello world!";
+        try (PrintWriter printWriter = new PrintWriter(dfsCluster1.create(path, true))) {
+            printWriter.println(testString);
+        }
+
+        // assert it can be read back using a Pipeline with config that doesn't know the FileSystem
+        Iterable<String> strings = new MRPipeline(getClass(), minimalConfiguration())
+            .read(From.textFile(path).fileSystem(dfsCluster1)).materialize();
+        Assert.assertEquals(testString, concatStrings(strings));
+
+        // write output with crunch using a Pipeline with config that doesn't know the FileSystem
+        MRPipeline pipeline = new MRPipeline(getClass(), minimalConfiguration());
+        PCollection<String> input = pipeline.read(From.textFile("hdfs://cluster1/input.txt").fileSystem(dfsCluster1));
+        pipeline.write(input, To.textFile("hdfs://cluster2/output").fileSystem(dfsCluster2));
+        pipeline.run();
+
+        // assert the output was written correctly
+        try (FSDataInputStream inputStream = dfsCluster2.open(new Path("hdfs://cluster2/output/out0-m-00000"))) {
+            String readValue = IOUtils.toString(inputStream).trim();
+            Assert.assertEquals(testString, readValue);
+        }
+
+        // make sure the clusters aren't getting mixed up
+        Assert.assertFalse(dfsCluster1.exists(new Path("/output")));
+    }
+
+    /**
+     * Tests that multiple calls to fileSystem() on Source, Target, or SourceTarget results in
+     * IllegalStateException
+     */
+    @Test
+    public void testResetFileSystem() {
+        Source<String> source = From.textFile("/data").fileSystem(defaultFs);
+        try {
+            source.fileSystem(dfsCluster1);
+            Assert.fail("Expected an IllegalStateException");
+        } catch (IllegalStateException e) { }
+
+        Target target = To.textFile("/data").fileSystem(defaultFs);
+        try {
+            target.fileSystem(dfsCluster1);
+            Assert.fail("Expected an IllegalStateException");
+        } catch (IllegalStateException e) { }
+
+        SourceTarget<String> sourceTarget = target.asSourceTarget(source.getType());
+        try {
+            sourceTarget.fileSystem(dfsCluster1);
+            Assert.fail("Expected an IllegalStateException");
+        } catch (IllegalStateException e) { }
+    }
+
+    /**
+     * Tests when supplied Filesystem is not in agreement with Path.  For example, Path is "hdfs://cluster1/data"
+     * but FileSystem is hdfs://cluster2.
+     */
+    @Test
+    public void testWrongFs() {
+        Source<String> source = From.textFile("hdfs://cluster1/data");
+        try {
+            source.fileSystem(dfsCluster2);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) { }
+
+        Target target = To.textFile("hdfs://cluster1/data");
+        try {
+            target.fileSystem(dfsCluster2);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) { }
+
+        SourceTarget<String> sourceTarget = target.asSourceTarget(source.getType());
+        try {
+            sourceTarget.fileSystem(dfsCluster2);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) { }
+    }
+
+    private static String concatStrings(Iterable<String> strings) {
+        StringBuilder builder = new StringBuilder();
+        for (String string : strings) {
+            builder.append(string);
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Creates a minimal configuration pointing to an HA HDFS default filesystem to ensure
+     * that configuration for external filesystems used in Sources and Targets doesn't mess up
+     * dfs.nameservices on the Pipeline, which could cause the default filesystem to become
+     * unresolveable.
+     *
+     * @return a minimal configuration with an HDFS HA default fs
+     */
+    private static Configuration minimalConfiguration() {
+        Configuration minimalConfiguration = new Configuration(false);
+        minimalConfiguration.addResource(defaultFs.getConf());
+        minimalConfiguration.set("fs.defaultFS", "hdfs://default");
+        // exposes bugs hidden by filesystem cache
+        minimalConfiguration.set("fs.hdfs.impl.disable.cache", "true");
+        return minimalConfiguration;
+    }
+
+    private static Configuration getDfsConf(String nsName, MiniDFSCluster cluster) {
+        Configuration conf = new Configuration();
+        conf.set("dfs.nameservices", nsName);
+        conf.set("dfs.client.failover.proxy.provider." + nsName,
+            "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
+        conf.set("dfs.ha.namenodes." + nsName, "nn1");
+        conf.set("dfs.namenode.rpc-address." + nsName + ".nn1", "localhost:" + cluster.getNameNodePort());
+        return conf;
+    }
+
+    private static FileSystem createHaMiniClusterFs(String clusterName, TemporaryPath temporaryPath)
+        throws IOException {
+        Configuration conf = new Configuration();
+        conf.set(HDFS_MINIDFS_BASEDIR, temporaryPath.getRootFileName());
+        MiniDFSCluster cluster = new Builder(conf).build();
+        miniDFSClusters.add(cluster);
+        return FileSystem.get(URI.create("hdfs://" + clusterName), getDfsConf(clusterName, cluster));
+    }
+}

--- a/crunch-core/src/main/java/org/apache/crunch/Source.java
+++ b/crunch-core/src/main/java/org/apache/crunch/Source.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapreduce.Job;
 
 /**
@@ -37,6 +38,26 @@ public interface Source<T> {
    * different values when necessary.
    */
   Source<T> inputConf(String key, String value);
+
+  /**
+   * Adds the {@code Configuration} of the given filesystem such that the source can read from it when the {@code
+   * Pipeline} itself does not have that configuration.
+   * </p>
+   * Changing the filesystem after it is set is not supported and will result in {@link
+   * IllegalStateException}
+   *
+   * @param fileSystem the filesystem
+   * @return this Source
+   * @throws IllegalStateException if the filesystem has already been set
+   * @throws IllegalArgumentException if the source is pointing to a fully qualified Path in a different FileSystem
+   */
+  Source<T> fileSystem(FileSystem fileSystem);
+
+  /**
+   * Returns the {@code FileSystem} for this source or null if no explicit filesystem {@link #fileSystem(FileSystem)
+   * has been set}.
+   */
+  FileSystem getFileSystem();
 
   /**
    * Returns the {@code PType} for this source.

--- a/crunch-core/src/main/java/org/apache/crunch/SourceTarget.java
+++ b/crunch-core/src/main/java/org/apache/crunch/SourceTarget.java
@@ -17,6 +17,8 @@
  */
 package org.apache.crunch;
 
+import org.apache.hadoop.fs.FileSystem;
+
 /**
  * An interface for classes that implement both the {@code Source} and the
  * {@code Target} interfaces.
@@ -29,4 +31,19 @@ public interface SourceTarget<T> extends Source<T>, Target {
    * re-use the same config keys with different values when necessary.
    */
   SourceTarget<T> conf(String key, String value);
+
+  /**
+   * Adds the {@code Configuration} of the given filesystem such that the source-target can read/write from/to it when
+   * the {@code Pipeline} itself does not have that configuration.
+   * </p>
+   * Changing the filesystem after it is set is not supported and will result in {@link
+   * IllegalStateException}
+   *
+   * @param fileSystem the filesystem
+   * @return this SourceTarget
+   * @throws IllegalStateException if the filesystem has already been set
+   * @throws IllegalArgumentException if the source/target is pointing to a fully qualified Path in a different
+   * FileSystem
+   */
+  SourceTarget<T> fileSystem(FileSystem fileSystem);
 }

--- a/crunch-core/src/main/java/org/apache/crunch/Target.java
+++ b/crunch-core/src/main/java/org/apache/crunch/Target.java
@@ -21,6 +21,7 @@ import org.apache.crunch.io.OutputHandler;
 import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 
 /**
  * A {@code Target} represents the output destination of a Crunch {@code PCollection}
@@ -66,6 +67,26 @@ public interface Target {
    * different values when necessary.
    */
   Target outputConf(String key, String value);
+
+  /**
+   * Adds the {@code Configuration} of the given filesystem such that the target can write to it when the {@code
+   * Pipeline} itself does not have that configuration.
+   * </p>
+   * Changing the filesystem after it is set is not supported and will result in {@link
+   * IllegalStateException}
+   *
+   * @param fileSystem the filesystem
+   * @return this Target
+   * @throws IllegalStateException if the filesystem has already been set
+   * @throws IllegalArgumentException if the target is pointing to a fully qualified Path in a different FileSystem
+   */
+  Target fileSystem(FileSystem fileSystem);
+
+  /**
+   * Returns the {@code FileSystem} for this target or null if no explicit filesystem {@link #fileSystem(FileSystem)
+   * has been set}.
+   */
+  FileSystem getFileSystem();
 
   /**
    * Apply the given {@code WriteMode} to this {@code Target} instance.

--- a/crunch-core/src/main/java/org/apache/crunch/io/avro/AvroFileTarget.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/avro/AvroFileTarget.java
@@ -88,7 +88,7 @@ public class AvroFileTarget extends FileTargetImpl {
   @Override
   public <T> SourceTarget<T> asSourceTarget(PType<T> ptype) {
     if (ptype instanceof AvroType) {
-      return new AvroFileSourceTarget<T>(path, (AvroType<T>) ptype);
+      return new AvroFileSourceTarget<T>(path, (AvroType<T>) ptype).fileSystem(getFileSystem());
     }
     return null;
   }

--- a/crunch-core/src/main/java/org/apache/crunch/io/impl/FileTargetImpl.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/impl/FileTargetImpl.java
@@ -259,7 +259,7 @@ public class FileTargetImpl implements PathTarget {
     }
   }
 
-  private void handeOutputsDistributedCopy(Configuration conf, Path srcPattern, FileSystem srcFs, FileSystem dstFs,
+  private void handleOutputsDistributedCopy(Configuration conf, Path srcPattern, FileSystem srcFs, FileSystem dstFs,
           int maxDistributedCopyTasks) throws IOException {
     Path[] srcs = FileUtil.stat2Paths(srcFs.globStatus(srcPattern), srcPattern);
     if (srcs.length > 0) {

--- a/crunch-core/src/main/java/org/apache/crunch/io/impl/FileTargetImpl.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/impl/FileTargetImpl.java
@@ -19,8 +19,10 @@ package org.apache.crunch.io.impl;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -63,9 +65,10 @@ public class FileTargetImpl implements PathTarget {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileTargetImpl.class);
   
-  protected final Path path;
+  protected Path path;
   private final FormatBundle<? extends FileOutputFormat> formatBundle;
   private final FileNamingScheme fileNamingScheme;
+  private FileSystem fileSystem;
 
   public FileTargetImpl(Path path, Class<? extends FileOutputFormat> outputFormatClass,
                         FileNamingScheme fileNamingScheme) {
@@ -88,6 +91,30 @@ public class FileTargetImpl implements PathTarget {
   public Target outputConf(String key, String value) {
     formatBundle.set(key, value);
     return this;
+  }
+
+  @Override
+  public Target fileSystem(FileSystem fileSystem) {
+    if (this.fileSystem != null) {
+      throw new IllegalStateException("Filesystem already set. Change is not supported.");
+    }
+
+    if (fileSystem != null) {
+      path = fileSystem.makeQualified(path);
+
+      this.fileSystem = fileSystem;
+
+      Configuration fsConf = fileSystem.getConf();
+      for (Entry<String, String> entry : fsConf) {
+        formatBundle.set(entry.getKey(), entry.getValue());
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    return fileSystem;
   }
 
   @Override
@@ -164,7 +191,8 @@ public class FileTargetImpl implements PathTarget {
   @Override
   public void handleOutputs(Configuration conf, Path workingPath, int index) throws IOException {
     FileSystem srcFs = workingPath.getFileSystem(conf);
-    FileSystem dstFs = path.getFileSystem(conf);
+    Configuration dstFsConf = getEffectiveBundleConfig(conf);
+    FileSystem dstFs = path.getFileSystem(dstFsConf);
     if (!dstFs.exists(path)) {
       dstFs.mkdirs(path);
     }
@@ -178,7 +206,7 @@ public class FileTargetImpl implements PathTarget {
       if (useDistributedCopy) {
         LOG.info("Source and destination are in different file systems, performing distributed copy from {} to {}", srcPattern,
             path);
-        handeOutputsDistributedCopy(conf, srcPattern, srcFs, dstFs, maxDistributedCopyTasks);
+        handleOutputsDistributedCopy(dstFsConf, srcPattern, srcFs, dstFs, maxDistributedCopyTasks);
       } else {
         LOG.info("Source and destination are in different file systems, performing asynch copies from {} to {}", srcPattern, path);
         handleOutputsAsynchronously(conf, srcPattern, srcFs, dstFs, sameFs, maxThreads);
@@ -198,8 +226,9 @@ public class FileTargetImpl implements PathTarget {
         MoreExecutors.listeningDecorator(
             Executors.newFixedThreadPool(
                 maxThreads));
+    Configuration dstFsConf = getEffectiveBundleConfig(conf);
     for (Path s : srcs) {
-      Path d = getDestFile(conf, s, path, s.getName().contains("-m-"));
+      Path d = getDestFile(dstFsConf, s, path, s.getName().contains("-m-"));
       renameFutures.add(
           executorService.submit(
               new WorkingPathFileMover(conf, s, d, srcFs, dstFs, sameFs)));
@@ -356,11 +385,16 @@ public class FileTargetImpl implements PathTarget {
     return null;
   }
 
+  private Configuration getEffectiveBundleConfig(Configuration configuration) {
+    // overlay the bundle config on top of a copy of the supplied config
+    return formatBundle.configure(new Configuration(configuration));
+  }
+
   @Override
   public boolean handleExisting(WriteMode strategy, long lastModForSource, Configuration conf) {
     FileSystem fs = null;
     try {
-      fs = path.getFileSystem(conf);
+      fs = path.getFileSystem(getEffectiveBundleConfig(conf));
     } catch (IOException e) {
       LOG.error("Could not retrieve FileSystem object to check for existing path", e);
       throw new CrunchRuntimeException(e);

--- a/crunch-core/src/main/java/org/apache/crunch/io/impl/SourceTargetImpl.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/impl/SourceTargetImpl.java
@@ -27,6 +27,7 @@ import org.apache.crunch.io.OutputHandler;
 import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapreduce.Job;
 
 class SourceTargetImpl<T> implements SourceTarget<T> {
@@ -43,6 +44,19 @@ class SourceTargetImpl<T> implements SourceTarget<T> {
   public Source<T> inputConf(String key, String value) {
     source.inputConf(key, value);
     return this;
+  }
+
+  @Override
+  public SourceTarget<T> fileSystem(FileSystem fileSystem) {
+    source.fileSystem(fileSystem);
+    target.fileSystem(fileSystem);
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    // could either return source or target filesytem as they are the same
+    return source.getFileSystem();
   }
 
   @Override

--- a/crunch-core/src/main/java/org/apache/crunch/io/parquet/AvroParquetFileTarget.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/parquet/AvroParquetFileTarget.java
@@ -102,7 +102,7 @@ public class AvroParquetFileTarget extends FileTargetImpl {
   @Override
   public <T> SourceTarget<T> asSourceTarget(PType<T> ptype) {
     if (ptype instanceof AvroType && IndexedRecord.class.isAssignableFrom(((AvroType) ptype).getTypeClass())) {
-      return new AvroParquetFileSourceTarget(path, (AvroType<T>) ptype);
+      return new AvroParquetFileSourceTarget(path, (AvroType<T>) ptype).fileSystem(getFileSystem());
     }
     return null;
   }

--- a/crunch-core/src/main/java/org/apache/crunch/io/seq/SeqFileTarget.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/seq/SeqFileTarget.java
@@ -47,9 +47,9 @@ public class SeqFileTarget extends FileTargetImpl {
   @Override
   public <T> SourceTarget<T> asSourceTarget(PType<T> ptype) {
     if (ptype instanceof PTableType) {
-      return new SeqFileTableSourceTarget(path, (PTableType) ptype);
+      return new SeqFileTableSourceTarget(path, (PTableType) ptype).fileSystem(getFileSystem());
     } else {
-      return new SeqFileSourceTarget(path, ptype);
+      return new SeqFileSourceTarget(path, ptype).fileSystem(getFileSystem());
     }
   }
 }

--- a/crunch-core/src/main/java/org/apache/crunch/io/text/TextFileTarget.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/text/TextFileTarget.java
@@ -98,9 +98,9 @@ public class TextFileTarget extends FileTargetImpl {
       return null;
     }
     if (ptype instanceof PTableType) {
-      return new TextFileTableSourceTarget(path, (PTableType) ptype);
+      return new TextFileTableSourceTarget(path, (PTableType) ptype).fileSystem(getFileSystem());
     }
-    return new TextFileSourceTarget<T>(path, ptype);
+    return new TextFileSourceTarget<T>(path, ptype).fileSystem(getFileSystem());
   }
   
   private <T> boolean isTextCompatible(PType<T> ptype) {

--- a/crunch-hbase/src/main/java/org/apache/crunch/io/hbase/HBaseSourceTarget.java
+++ b/crunch-hbase/src/main/java/org/apache/crunch/io/hbase/HBaseSourceTarget.java
@@ -35,6 +35,7 @@ import org.apache.crunch.types.PTableType;
 import org.apache.crunch.types.PType;
 import org.apache.crunch.types.writable.Writables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
@@ -125,6 +126,12 @@ public class HBaseSourceTarget extends HBaseTarget implements
   @Override
   public Source<Pair<ImmutableBytesWritable, Result>> inputConf(String key, String value) {
     inputBundle.set(key, value);
+    return this;
+  }
+
+  @Override
+  public SourceTarget<Pair<ImmutableBytesWritable, Result>> fileSystem(FileSystem fileSystem) {
+    // not currently supported/applicable for HBase
     return this;
   }
 

--- a/crunch-hbase/src/main/java/org/apache/crunch/io/hbase/HBaseTarget.java
+++ b/crunch-hbase/src/main/java/org/apache/crunch/io/hbase/HBaseTarget.java
@@ -32,6 +32,7 @@ import org.apache.crunch.io.OutputHandler;
 import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
@@ -143,6 +144,18 @@ public class HBaseTarget implements MapReduceTarget {
   public Target outputConf(String key, String value) {
     extraConf.put(key, value);
     return this;
+  }
+
+  @Override
+  public Target fileSystem(FileSystem fileSystem) {
+    // not currently supported/applicable for HBase
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    // not currently supported/applicable for HBase
+    return null;
   }
 
   @Override

--- a/crunch-hcatalog/src/main/java/org/apache/crunch/io/hcatalog/HCatSourceTarget.java
+++ b/crunch-hcatalog/src/main/java/org/apache/crunch/io/hcatalog/HCatSourceTarget.java
@@ -35,6 +35,7 @@ import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.crunch.types.writable.Writables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -132,6 +133,18 @@ public class HCatSourceTarget extends HCatTarget implements ReadableSourceTarget
   public Source<HCatRecord> inputConf(String key, String value) {
     bundle.set(key, value);
     return this;
+  }
+
+  @Override
+  public SourceTarget<HCatRecord> fileSystem(FileSystem fileSystem) {
+    // not currently supported/applicable for HCatalog
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    // not currently supported/applicable for HCatalog
+    return null;
   }
 
   @Override

--- a/crunch-hcatalog/src/main/java/org/apache/crunch/io/hcatalog/HCatTarget.java
+++ b/crunch-hcatalog/src/main/java/org/apache/crunch/io/hcatalog/HCatTarget.java
@@ -33,6 +33,7 @@ import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.crunch.types.writable.Writables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -168,6 +169,18 @@ public class HCatTarget implements MapReduceTarget {
   public Target outputConf(String key, String value) {
     bundle.set(key, value);
     return this;
+  }
+
+  @Override
+  public Target fileSystem(FileSystem fileSystem) {
+    // not currently supported/applicable for HCatalog
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    // not currently supported/applicable for HCatalog
+    return null;
   }
 
   @Override

--- a/crunch-hive/src/main/java/org/apache/crunch/io/orc/OrcFileTarget.java
+++ b/crunch-hive/src/main/java/org/apache/crunch/io/orc/OrcFileTarget.java
@@ -45,7 +45,7 @@ public class OrcFileTarget extends FileTargetImpl {
   
   @Override
   public <T> SourceTarget<T> asSourceTarget(PType<T> ptype) {
-    return new OrcFileSourceTarget<T>(path, ptype);
+    return new OrcFileSourceTarget<T>(path, ptype).fileSystem(getFileSystem());
   }
   
 }

--- a/crunch-kafka/src/main/java/org/apache/crunch/kafka/KafkaSource.java
+++ b/crunch-kafka/src/main/java/org/apache/crunch/kafka/KafkaSource.java
@@ -33,6 +33,7 @@ import org.apache.crunch.types.PTableType;
 import org.apache.crunch.types.PType;
 import org.apache.crunch.types.writable.Writables;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapreduce.Job;
@@ -111,6 +112,18 @@ public class KafkaSource
   public Source<Pair<BytesWritable, BytesWritable>> inputConf(String key, String value) {
     inputBundle.set(key, value);
     return this;
+  }
+
+  @Override
+  public Source<Pair<BytesWritable, BytesWritable>> fileSystem(FileSystem fileSystem) {
+    // not currently applicable/supported for Kafka
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    // not currently applicable/supported for Kafka
+    return null;
   }
 
   @Override

--- a/crunch-kafka/src/main/java/org/apache/crunch/kafka/record/KafkaSource.java
+++ b/crunch-kafka/src/main/java/org/apache/crunch/kafka/record/KafkaSource.java
@@ -27,6 +27,7 @@ import org.apache.crunch.io.ReadableSource;
 import org.apache.crunch.types.Converter;
 import org.apache.crunch.types.PType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapreduce.Job;
@@ -98,6 +99,18 @@ public class KafkaSource
   public Source<ConsumerRecord<BytesWritable, BytesWritable>> inputConf(String key, String value) {
     inputBundle.set(key, value);
     return this;
+  }
+
+  @Override
+  public Source<ConsumerRecord<BytesWritable, BytesWritable>> fileSystem(FileSystem fileSystem) {
+    // not currently applicable/supported for Kafka
+    return this;
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    // not currently applicable/supported for Kafka
+    return null;
   }
 
   @Override


### PR DESCRIPTION
The change to Source, Target, and SourceTarget obviously breaks compatibility for implementors of these interfaces as we're still building against Java 7 so I can't provide a default implementation for these new methods.

Also, there is an expectation that Target implementations will need to update the asSourceTarget() method to copy the FileSystem along.