### PR TITLE
CRUNCH-680: Kafka Source should split very large partitions

### DIFF
--- a/crunch-kafka/src/main/java/org/apache/crunch/kafka/record/KafkaSource.java
+++ b/crunch-kafka/src/main/java/org/apache/crunch/kafka/record/KafkaSource.java
@@ -163,6 +163,9 @@ public class KafkaSource
     props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
     props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
 
+    //disable automatic committing of consumer offsets
+    props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.toString(false));
+
     return props;
   }
 

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaInputFormatTest.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaInputFormatTest.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.crunch.kafka.record;
+
+import org.apache.crunch.io.FormatBundle;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class KafkaInputFormatTest {
+
+  @Test
+  public void generateConnectionPropertyKeyTest() {
+    String propertyName = "some.property";
+    String actual = KafkaInputFormat.generateConnectionPropertyKey(propertyName);
+    String expected = "org.apache.crunch.kafka.connection.properties.some.property";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void getConnectionPropertyFromKeyTest() {
+    String prefixedConnectionProperty = "org.apache.crunch.kafka.connection.properties.some.property";
+    String actual = KafkaInputFormat.getConnectionPropertyFromKey(prefixedConnectionProperty);
+    String expected = "some.property";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void writeConnectionPropertiesToBundleTest() {
+    FormatBundle<KafkaInputFormat> actual = FormatBundle.forInput(KafkaInputFormat.class);
+    Properties connectionProperties = new Properties();
+    connectionProperties.put("key1", "value1");
+    connectionProperties.put("key2", "value2");
+    KafkaInputFormat.writeConnectionPropertiesToBundle(connectionProperties, actual);
+
+    FormatBundle<KafkaInputFormat> expected = FormatBundle.forInput(KafkaInputFormat.class);
+    expected.set("org.apache.crunch.kafka.connection.properties.key1", "value1");
+    expected.set("org.apache.crunch.kafka.connection.properties.key2", "value2");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void filterConnectionPropertiesTest() {
+    Properties props = new Properties();
+    props.put("org.apache.crunch.kafka.connection.properties.key1", "value1");
+    props.put("org.apache.crunch.kafka.connection.properties.key2", "value2");
+    props.put("org_apache_crunch_kafka_connection_properties.key3", "value3");
+    props.put("org.apache.crunch.another.prefix.properties.key4", "value4");
+
+    Properties actual = KafkaInputFormat.filterConnectionProperties(props);
+    Properties expected = new Properties();
+    expected.put("key1", "value1");
+    expected.put("key2", "value2");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void getSplitsInvalidMaxRecords() throws IOException, InterruptedException {
+    KafkaInputFormat kafkaInputFormat = new KafkaInputFormat();
+    Configuration conf = new Configuration(false);
+    conf.setLong(KafkaInputFormat.KAFKA_MAX_RECORDS_PER_SPLIT, 0L);
+    kafkaInputFormat.setConf(conf);
+    kafkaInputFormat.getSplits(mock(JobContext.class));
+  }
+
+  @Test
+  public void getSplitsConfiguredMaxRecords() throws IOException, InterruptedException {
+    KafkaInputFormat kafkaInputFormat = new KafkaInputFormat();
+    Configuration conf = new Configuration(false);
+    conf.setLong(KafkaInputFormat.KAFKA_MAX_RECORDS_PER_SPLIT, 2L);
+
+    conf.set("org.apache.crunch.kafka.offsets.topic.abc.partitions", "0,1");
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.0.start", 300L);
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.0.end", 1000L);
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.1.start", 30L);
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.1.end", 100L);
+
+    conf.set("org.apache.crunch.kafka.offsets.topic.xyz.partitions", "0");
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.xyz.partitions.0.start", 3L);
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.xyz.partitions.0.end", 10L);
+
+    kafkaInputFormat.setConf(conf);
+    List<InputSplit> splits = kafkaInputFormat.getSplits(mock(JobContext.class));
+    assertThat(splits.size(), is((700/2 + 700%2) + (70/2 + 70%2) + (7/2 + 7%2)));
+  }
+
+  @Test
+  public void getSplitsDefaultMaxRecords() throws IOException, InterruptedException {
+    KafkaInputFormat kafkaInputFormat = new KafkaInputFormat();
+    Configuration conf = new Configuration(false);
+
+    conf.set("org.apache.crunch.kafka.offsets.topic.abc.partitions", "0");
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.0.start", 0L);
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.0.end", 5234567L);
+
+    kafkaInputFormat.setConf(conf);
+    List<InputSplit> splits = kafkaInputFormat.getSplits(mock(JobContext.class));
+    assertThat(splits.size(), is(2));
+  }
+
+  @Test
+  public void getSplitsNoRecords() throws IOException, InterruptedException {
+    KafkaInputFormat kafkaInputFormat = new KafkaInputFormat();
+    Configuration conf = new Configuration(false);
+
+    conf.set("org.apache.crunch.kafka.offsets.topic.abc.partitions", "0");
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.0.start", 5L);
+    conf.setLong("org.apache.crunch.kafka.offsets.topic.abc.partitions.0.end", 5L);
+
+    kafkaInputFormat.setConf(conf);
+    List<InputSplit> splits = kafkaInputFormat.getSplits(mock(JobContext.class));
+    assertThat(splits.size(), is(0));
+  }
+}

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaRecordReaderTest.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaRecordReaderTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a
+ * copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.apache.crunch.kafka.record;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.DisconnectException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KafkaRecordReaderTest {
+
+  @Mock
+  private KafkaConsumer<String, String> consumer;
+
+  @Mock
+  private TaskAttemptContext taskAttemptContext;
+
+  private TopicPartition topicPartition;
+  private long startOffset;
+  private long endOffset;
+  private KafkaInputSplit inputSplit;
+
+  private ConsumerRecords<String, String> records;
+
+  private KafkaRecordReader<String, String> reader;
+
+  @Before
+  public void before() throws IOException, InterruptedException {
+    when(taskAttemptContext.getConfiguration()).thenReturn(new Configuration(false));
+    startOffset = 0L;
+    endOffset = 100L;
+    topicPartition = new TopicPartition("topic", 0);
+
+    inputSplit = new KafkaInputSplit(topicPartition.topic(), topicPartition.partition(), startOffset, endOffset);
+
+    when(consumer.beginningOffsets(Collections.singleton(inputSplit.getTopicPartition()))).thenReturn(
+        Collections.singletonMap(inputSplit.getTopicPartition(), 0L));
+
+    records = new ConsumerRecords<>(Collections.singletonMap(inputSplit.getTopicPartition(),
+        Collections.singletonList(new ConsumerRecord<>("topic", 0, 0, "key", "value"))));
+
+    when(consumer.poll(anyLong())).thenReturn(records);
+
+    reader = new KafkaRecordReaderTester();
+    reader.initialize(inputSplit, taskAttemptContext);
+  }
+
+  @Test
+  public void getRecords_consumerPollThrowsException_thenReturnsMessage() {
+    // DisconnectException is retriable
+    when(consumer.poll(anyLong())).thenThrow(new DisconnectException()).thenReturn(records);
+
+    reader.loadRecords();
+    Iterator<ConsumerRecord<String, String>> iterator = reader.getRecordIterator();
+    assertThat(iterator.hasNext(), is(true));
+    assertThat(iterator.next(), is(records.records(topicPartition).get(0)));
+  }
+
+  @Test
+  public void getRecords_consumerPollEmpty_thenReturnsMessage() {
+    // DisconnectException is retriable
+    when(consumer.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.<TopicPartition,
+        List<ConsumerRecord<String, String>>> emptyMap())).thenReturn(records);
+
+    reader.loadRecords();
+    Iterator<ConsumerRecord<String, String>> iterator = reader.getRecordIterator();
+    assertThat(iterator.hasNext(), is(true));
+    assertThat(iterator.next(), is(records.records(topicPartition).get(0)));
+  }
+
+  @Test
+  public void nextKeyValue() throws IOException, InterruptedException {
+    assertThat(reader.nextKeyValue(), is(true));
+    assertThat(reader.getCurrentKey(), is(records.records(topicPartition).get(0)));
+    assertThat(reader.getCurrentOffset(), is(0L));
+  }
+
+  @Test
+  public void nextKeyValue_recordOffsetAheadOfExpected() throws IOException, InterruptedException {
+    records = new ConsumerRecords<>(Collections.singletonMap(inputSplit.getTopicPartition(),
+        Collections.singletonList(new ConsumerRecord<>("topic", 0, 10L, "key", "value"))));
+
+    when(consumer.poll(anyLong())).thenReturn(records);
+
+    assertThat(reader.nextKeyValue(), is(true));
+    assertThat(reader.getCurrentKey(), is(records.records(topicPartition).get(0)));
+    assertThat(reader.getCurrentOffset(), is(10L));
+  }
+
+  @Test
+  public void nextKeyValue_noRecord_emptyPartition() throws IOException, InterruptedException {
+    when(consumer.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.<TopicPartition,
+        List<ConsumerRecord<String, String>>> emptyMap()));
+
+    when(consumer.beginningOffsets(Collections.singletonList(topicPartition))).thenReturn(
+        Collections.singletonMap(topicPartition, endOffset));
+
+    assertThat(reader.nextKeyValue(), is(false));
+  }
+
+  @Test(expected = IOException.class)
+  public void nextKeyValue_noRecord_nonEmptyPartition() throws IOException, InterruptedException {
+    when(consumer.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.<TopicPartition,
+        List<ConsumerRecord<String, String>>> emptyMap()));
+
+    reader.nextKeyValue();
+  }
+
+  @Test
+  public void nextKeyValue_recordIsBeyondEndOffset() throws IOException, InterruptedException {
+    records = new ConsumerRecords<>(Collections.singletonMap(inputSplit.getTopicPartition(),
+        Collections.singletonList(new ConsumerRecord<>("topic", 0, 100L, "key", "value"))));
+
+    when(consumer.poll(anyLong())).thenReturn(records);
+
+    assertThat(reader.nextKeyValue(), is(false));
+  }
+
+  @Test
+  public void getEarliestOffset_noOffsetFound() {
+    when(consumer.beginningOffsets(Collections.singletonList(inputSplit.getTopicPartition()))).thenReturn(
+        Collections.<TopicPartition, Long> emptyMap());
+    assertThat(reader.getEarliestOffset(), is(0L));
+  }
+
+  @Test
+  public void getEarliestOffset() {
+    when(consumer.beginningOffsets(Collections.singletonList(inputSplit.getTopicPartition()))).thenReturn(
+        Collections.singletonMap(inputSplit.getTopicPartition(), 100L));
+    assertThat(reader.getEarliestOffset(), is(100L));
+  }
+
+  private class KafkaRecordReaderTester extends KafkaRecordReader<String, String> {
+    @Override
+    protected KafkaConsumer<String, String> buildConsumer(Properties properties) {
+      return consumer;
+    }
+  }
+}


### PR DESCRIPTION
Introduces relatively straightforward logic to chunk very large partitions into multiple splits. Some missing unit tests were also added in.