### PR TITLE
The great version upgrade PR

### DIFF
--- a/crunch-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/crunch-archetype/src/main/resources/archetype-resources/pom.xml
@@ -89,8 +89,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/crunch-core/pom.xml
+++ b/crunch-core/pom.xml
@@ -42,7 +42,6 @@ under the License.
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>${avro.classifier}</classifier>
     </dependency>
 
     <dependency>
@@ -64,6 +63,12 @@ under the License.
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -142,7 +147,7 @@ under the License.
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/crunch-core/pom.xml
+++ b/crunch-core/pom.xml
@@ -50,6 +50,11 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>com.thoughtworks.paranamer</groupId>
+      <artifactId>paranamer</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>

--- a/crunch-core/src/it/java/org/apache/crunch/io/parquet/AvroParquetFileSourceTargetIT.java
+++ b/crunch-core/src/it/java/org/apache/crunch/io/parquet/AvroParquetFileSourceTargetIT.java
@@ -153,7 +153,7 @@ public class AvroParquetFileSourceTargetIT implements Serializable {
 
     Person person = Iterables.getOnlyElement(ageOnly.materialize());
     assertNull(person.getName());
-    assertEquals(person.getAge(), new Integer(42));
+    assertEquals(person.getAge(), 42);
     assertNull(person.getSiblingnames());
   }
 

--- a/crunch-core/src/it/java/org/apache/crunch/io/parquet/AvroParquetFileSourceTargetIT.java
+++ b/crunch-core/src/it/java/org/apache/crunch/io/parquet/AvroParquetFileSourceTargetIT.java
@@ -153,7 +153,7 @@ public class AvroParquetFileSourceTargetIT implements Serializable {
 
     Person person = Iterables.getOnlyElement(ageOnly.materialize());
     assertNull(person.getName());
-    assertEquals(person.getAge(), 42);
+    assertEquals(person.getAge().intValue(), 42);
     assertNull(person.getSiblingnames());
   }
 

--- a/crunch-core/src/main/java/org/apache/crunch/io/parquet/AvroParquetFileSource.java
+++ b/crunch-core/src/main/java/org/apache/crunch/io/parquet/AvroParquetFileSource.java
@@ -186,7 +186,7 @@ public class AvroParquetFileSource<T extends IndexedRecord> extends FileSourceIm
       if (field == null) {
         throw new IllegalArgumentException("No field " + fieldName + " in schema: " + baseSchema.getName());
       }
-      fields.add(new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultValue(), field.order()));
+      fields.add(new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal(), field.order()));
       return this;
     }
 

--- a/crunch-core/src/main/java/org/apache/crunch/util/CrunchRenameCopyListing.java
+++ b/crunch-core/src/main/java/org/apache/crunch/util/CrunchRenameCopyListing.java
@@ -219,7 +219,7 @@ public class CrunchRenameCopyListing extends SimpleCopyListing {
           DistCpUtils.getRelativePath(sourcePathRoot, fileStatus.getPath()), fileStatus.getPath());
     }
 
-    if (!shouldCopy(fileStatus.getPath(), options)) {
+    if (!shouldCopy(fileStatus.getPath())) {
       return;
     }
 

--- a/crunch-core/src/test/java/org/apache/crunch/io/parquet/AvroParquetFileReaderFactoryTest.java
+++ b/crunch-core/src/test/java/org/apache/crunch/io/parquet/AvroParquetFileReaderFactoryTest.java
@@ -98,7 +98,7 @@ public class AvroParquetFileReaderFactoryTest {
   }
 
   public static Schema.Field cloneField(Schema.Field field) {
-    return new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultValue());
+    return new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultVal());
   }
 
 }

--- a/crunch-core/src/test/java/org/apache/crunch/types/avro/AvroModeTest.java
+++ b/crunch-core/src/test/java/org/apache/crunch/types/avro/AvroModeTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -150,30 +149,6 @@ public class AvroModeTest {
     mode.configure(config);
     AvroMode returnedMode = AvroMode.fromConfiguration(config);
     assertThat(returnedMode.getFactory(), is(instanceOf(FakeReaderWriterFactory.class)));
-  }
-
-  @Test
-  public void testRegisterClassLoader() {
-    // First make sure things are in the default situation
-    AvroMode.setSpecificClassLoader(null);
-
-    ClassLoader classLoaderA = mock(ClassLoader.class);
-    ClassLoader classLoaderB = mock(ClassLoader.class);
-
-    // Basic sanity check to ensure that the class loader was really nulled out
-    assertNull(AvroMode.getSpecificClassLoader());
-
-    // Do an internal registration of a class loader. Because there is currently no internal class loader set,
-    // this should set the internal specific class loader
-    AvroMode.registerSpecificClassLoaderInternal(classLoaderA);
-
-    assertEquals(classLoaderA, AvroMode.getSpecificClassLoader());
-
-    // Now we do an internal register of another class loader. Because there already is an internal specific class
-    // loader set, this should have no impact (as opposed to calling setSpecificClassLoader)
-    AvroMode.registerSpecificClassLoaderInternal(classLoaderB);
-
-    assertEquals(classLoaderA, AvroMode.getSpecificClassLoader());
   }
 
   private static class FakeReaderWriterFactory implements ReaderWriterFactory{

--- a/crunch-kafka/pom.xml
+++ b/crunch-kafka/pom.xml
@@ -40,7 +40,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.11</artifactId>
+      <artifactId>kafka_${scala.base.version}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/crunch-kafka/src/main/java/org/apache/crunch/kafka/KafkaUtils.java
+++ b/crunch-kafka/src/main/java/org/apache/crunch/kafka/KafkaUtils.java
@@ -34,7 +34,7 @@ import org.apache.crunch.CrunchRuntimeException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol; 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/KafkaRecordsIterableIT.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/KafkaRecordsIterableIT.java
@@ -385,8 +385,6 @@ public class KafkaRecordsIterableIT {
           entry.getKey().partition(), entry.getValue() + 1, "key", null));
     }
 
-    when(records.isEmpty()).thenReturn(false);
-    when(records.iterator()).thenReturn(returnedRecords.iterator());
     when(mockedConsumer.poll(Matchers.anyLong()))
         //for the fill poll call
         .thenReturn(null)

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/KafkaUtilsIT.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/KafkaUtilsIT.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaRecordReaderTest.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaRecordReaderTest.java
@@ -63,9 +63,6 @@ public class KafkaRecordReaderTest {
 
     inputSplit = new KafkaInputSplit(topicPartition.topic(), topicPartition.partition(), startOffset, endOffset);
 
-    when(consumer.beginningOffsets(Collections.singleton(inputSplit.getTopicPartition()))).thenReturn(
-        Collections.singletonMap(inputSplit.getTopicPartition(), 0L));
-
     records = new ConsumerRecords<>(Collections.singletonMap(inputSplit.getTopicPartition(),
         Collections.singletonList(new ConsumerRecord<>("topic", 0, 0, "key", "value"))));
 

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaRecordsIterableIT.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/record/KafkaRecordsIterableIT.java
@@ -388,8 +388,6 @@ public class KafkaRecordsIterableIT {
           entry.getKey().partition(), entry.getValue() + 1, "key", null));
     }
 
-    when(records.isEmpty()).thenReturn(false);
-    when(records.iterator()).thenReturn(returnedRecords.iterator());
     when(mockedConsumer.poll(Matchers.anyLong()))
         //for the fill poll call
         .thenReturn(null)

--- a/crunch-kafka/src/test/java/org/apache/crunch/kafka/utils/KafkaBrokerTestHarness.java
+++ b/crunch-kafka/src/test/java/org/apache/crunch/kafka/utils/KafkaBrokerTestHarness.java
@@ -323,6 +323,7 @@ public class KafkaBrokerTestHarness extends ZookeeperTestHarness {
       props.setProperty("num.partitions", String.valueOf(PARTITIONS_PER_TOPIC));
       props.setProperty("default.replication.factor", String.valueOf(brokers));
       props.setProperty("auto.create.topics.enable", Boolean.FALSE.toString());
+      props.setProperty("offsets.topic.replication.factor", String.valueOf(brokers));
 
       props.putAll(baseProperties);
 

--- a/crunch-spark/src/main/scala/org/apache/crunch/scrunch/spark/ByteBufferInputStream.scala
+++ b/crunch-spark/src/main/scala/org/apache/crunch/scrunch/spark/ByteBufferInputStream.scala
@@ -55,7 +55,7 @@ class ByteBufferInputStream(private var buffer: ByteBuffer)
   override def skip(bytes: Long): Long = {
     if (buffer != null) {
       val amountToSkip = math.min(bytes, buffer.remaining).toInt
-      buffer.position(buffer.position + amountToSkip)
+      buffer.position(buffer.position() + amountToSkip)
       if (buffer.remaining() == 0) {
         cleanUp()
       }

--- a/crunch-test/pom.xml
+++ b/crunch-test/pom.xml
@@ -68,7 +68,7 @@ under the License.
     
     <dependency>
        <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -524,11 +524,6 @@ under the License.
      </dependency>
      <dependency>
        <groupId>org.apache.hadoop</groupId>
-       <artifactId>hadoop-hdfs</artifactId>
-       <version>${hadoop.version}</version>
-     </dependency>
-     <dependency>
-       <groupId>org.apache.hadoop</groupId>
        <artifactId>hadoop-mapreduce-client-core</artifactId>
        <version>${hadoop.version}</version>
      </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@ under the License.
     <commons-lang.version>2.6</commons-lang.version>
     <commons-codec.version>1.4</commons-codec.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <avro.version>1.9.1</avro.version>
+    <avro.version>1.8.2</avro.version>
     <hive.version>2.1.0</hive.version>
-    <parquet.version>1.8.1</parquet.version>
+    <parquet.version>1.10.1</parquet.version>
     <javassist.version>3.16.1-GA</javassist.version>
     <jackson.databind.version>2.6.1</jackson.databind.version>
     <protobuf-java.version>2.5.0</protobuf-java.version>
@@ -106,7 +106,7 @@ under the License.
 
     <kafka.version>1.1.0</kafka.version>
     <scala.base.version>2.12</scala.base.version>
-    <scala.version>2.12.6</scala.version>
+    <scala.version>2.12.10</scala.version>
     <scalatest.version>3.0.1</scalatest.version>
     <spark.version>2.4.0</spark.version>
     <jline.version>2.12.1</jline.version>
@@ -278,7 +278,7 @@ under the License.
         <exclusions>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-core</artifactId>
+            <artifactId>hadoop-client</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -641,7 +641,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.8.1</version>
           <configuration>
             <source>${java.source.version}</source>
             <target>${java.target.version}</target>
@@ -689,7 +689,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.5.4</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>net.alchim31.maven</groupId>
@@ -701,6 +701,7 @@ under the License.
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.2</version>
           <configuration>
+            <useSystemClassLoader>false</useSystemClassLoader>
             <argLine>-Xmx2G -Dfile.encoding=UTF-8</argLine>
           </configuration>
         </plugin>
@@ -712,7 +713,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>2.10</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ under the License.
     <jackson.databind.version>2.6.1</jackson.databind.version>
     <protobuf-java.version>2.5.0</protobuf-java.version>
     <libthrift.version>0.8.0</libthrift.version>
-    <slf4j.version>1.6.1</slf4j.version>
+    <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>1.2.15</log4j.version>
     <algebird.version>0.13.2</algebird.version>
     <junit.version>4.10</junit.version>
@@ -269,6 +269,12 @@ under the License.
             <artifactId>avro-ipc</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.thoughtworks.paranamer</groupId>
+        <artifactId>paranamer</artifactId>
+        <version>2.8</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@ under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.source.version>1.7</java.source.version>
-    <java.target.version>1.7</java.target.version>
+    <java.source.version>1.8</java.source.version>
+    <java.target.version>1.8</java.target.version>
     <!--
         NOTE: Please don't change any dependency versions here without
               checking first that they match those on Hadoop's runtime
@@ -85,7 +85,7 @@ under the License.
     <commons-lang.version>2.6</commons-lang.version>
     <commons-codec.version>1.4</commons-codec.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <avro.version>1.7.7</avro.version>
+    <avro.version>1.9.1</avro.version>
     <hive.version>2.1.0</hive.version>
     <parquet.version>1.8.1</parquet.version>
     <javassist.version>3.16.1-GA</javassist.version>
@@ -94,22 +94,21 @@ under the License.
     <libthrift.version>0.8.0</libthrift.version>
     <slf4j.version>1.6.1</slf4j.version>
     <log4j.version>1.2.15</log4j.version>
-    <algebird.version>0.9.0</algebird.version>
+    <algebird.version>0.13.2</algebird.version>
     <junit.version>4.10</junit.version>
     <hamcrest.version>1.1</hamcrest.version>
-    <mockito.version>1.9.0</mockito.version>
+    <mockito.version>2.23.4</mockito.version>
     <pkg>org.apache.crunch</pkg>
 
-    <hadoop.version>2.7.1</hadoop.version>
+    <hadoop.version>2.8.2</hadoop.version>
     <hbase.version>2.0.1</hbase.version>
-    <avro.classifier>hadoop2</avro.classifier>
     <hive.version>2.1.0</hive.version>
 
-    <kafka.version>0.10.2.1</kafka.version>
-    <scala.base.version>2.11</scala.base.version>
-    <scala.version>2.11.8</scala.version>
-    <scalatest.version>2.2.4</scalatest.version>
-    <spark.version>2.0.0</spark.version>
+    <kafka.version>1.1.0</kafka.version>
+    <scala.base.version>2.12</scala.base.version>
+    <scala.version>2.12.6</scala.version>
+    <scalatest.version>3.0.1</scalatest.version>
+    <spark.version>2.4.0</spark.version>
     <jline.version>2.12.1</jline.version>
     <jsr305.version>1.3.9</jsr305.version>
   </properties>
@@ -202,6 +201,12 @@ under the License.
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdfs</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-minicluster</artifactId>
         <version>${hadoop.version}</version>
       </dependency>
@@ -258,7 +263,6 @@ under the License.
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-mapred</artifactId>
         <version>${avro.version}</version>
-        <classifier>${avro.classifier}</classifier>
         <exclusions>
           <exclusion>
             <groupId>org.apache.avro</groupId>
@@ -391,7 +395,7 @@ under the License.
     
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
       </dependency>
            
@@ -695,9 +699,9 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18.1</version>
+          <version>2.22.2</version>
           <configuration>
-            <argLine>-Xmx2G -XX:PermSize=512m -XX:MaxPermSize=1G -Dfile.encoding=UTF-8</argLine>
+            <argLine>-Xmx2G -Dfile.encoding=UTF-8</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -708,7 +712,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.10</version>
+          <version>2.22.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -837,9 +841,8 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>2.22.2</version>
         <configuration>
-          <argLine>-Xmx2g -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512m -Dfile.encoding=UTF-8</argLine>
           <testSourceDirectory>${basedir}/src/it/java</testSourceDirectory>
         </configuration>
         <executions>


### PR DESCRIPTION
In order to stay in sync w/our primary upstream dependencies, I bit the bullet and made all of the changes required to make Crunch work against Hadoop 2.8.2 and (hopefully) later. It's a large set of small/no-op changes, but version dependency changes like this are always sort of spicy so I'll get some eyes on it before I push it in.